### PR TITLE
 Fix misleading error messages for PyPI installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-09-30
+
+### Fixed
+- Misleading error messages when running playground from PyPI installs ([#3](https://github.com/bogdan-pistol/dakora/issues/3))
+- CLI now correctly detects pre-built UI and shows success message instead of "UI build failed"
+
 ## [1.0.1] - 2025-09-30
 
 ### Fixed
@@ -40,5 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Template registry pattern with local filesystem implementation
 - Comprehensive test suite (unit, integration, performance)
 
+[1.0.2]: https://github.com/bogdan-pistol/dakora/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/bogdan-pistol/dakora/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/bogdan-pistol/dakora/releases/tag/v1.0.0

--- a/dakora/cli.py
+++ b/dakora/cli.py
@@ -80,6 +80,12 @@ def _build_ui():
     web_dir = package_root / "web"
     playground_dir = package_root / "playground"
 
+    # Check if playground is already built (e.g., from PyPI package)
+    if (playground_dir / "index.html").exists() and not web_dir.exists():
+        typer.echo("✅ Using pre-built UI from package")
+        return True
+
+    # For development installs, check if we need to build
     if not web_dir.exists():
         typer.echo("❌ Web UI source not found. This may be a development installation issue.", err=True)
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dakora"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Python library for managing and rendering prompt templates with type-safe inputs, versioning, and optional logging"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
  ## Summary

  Fixes confusing error messages when running `dakora playground` from PyPI installations. Users were seeing "UI build failed" messages even though the playground worked perfectly.

  ## Problem

  When users install dakora from PyPI and run `dakora playground`, they see:
  ❌ Web UI source not found. This may be a development installation issue.
  ⚠️  UI build failed, starting with fallback interface

  But the playground works fine because PyPI packages include pre-built UI assets.

  ## Solution

  Updated the `_build_ui()` function to check for pre-built playground files before checking for web/ source directory. Now PyPI installs show:
  ✅ Using pre-built UI from package

  ## Changes

  - Check if `playground/index.html` exists before validating `web/` directory
  - Show success message for pre-built UI (PyPI installs)
  - Maintain proper error handling for development installs without source

  ## Testing

  Tested with fresh PyPI install - confirms proper detection and messaging.

  Closes #3
