### PR TITLE
Fix: path to assets folder in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="A lightweight, type-safe prompt management platform for Python: live updates, versioning, validation, and optional logging.">
 
     <!-- Favicon -->
-    <link rel="icon" href="docs/assets/logo.svg" type="image/svg+xml">
+    <link rel="icon" href=".github/assets/logo.svg" type="image/svg+xml">
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
@@ -657,7 +657,7 @@
     <header class="header">
         <nav class="nav container">
             <a href="#" class="logo">
-                <img src="docs/assets/logo.svg" alt="Dakora Logo">
+                <img src=".github/assets/logo.svg" alt="Dakora Logo">
                 Dakora
             </a>
             <ul class="nav-links">
@@ -665,6 +665,7 @@
                 <li><a href="#features">Features</a></li>
                 <li><a href="#quickstart">Quick Start</a></li>
                 <li><a href="#examples">Examples</a></li>
+                <li><a href="https://dakora.mintlify.app/" target="_blank">Docs</a></li>
                 <li><a href="#contribute">Contribute</a></li>
             </ul>
             <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
@@ -681,6 +682,7 @@
         <a href="#features" onclick="toggleMobileMenu()">Features</a>
         <a href="#quickstart" onclick="toggleMobileMenu()">Quick Start</a>
         <a href="#examples" onclick="toggleMobileMenu()">Examples</a>
+        <a href="https://dakora.mintlify.app/" target="_blank">Docs</a>
         <a href="#contribute" onclick="toggleMobileMenu()">Contribute</a>
     </div>
 
@@ -743,7 +745,7 @@
             </div>
 
             <div class="playground-demo">
-                <img src="docs/assets/playground-interface.png" alt="Dakora Playground Interface" class="playground-screenshot">
+                <img src=".github/assets/playground-interface.png" alt="Dakora Playground Interface" class="playground-screenshot">
                 <div class="playground-features">
                     <div class="playground-feature">
                         <i class="fas fa-edit"></i>
@@ -984,6 +986,7 @@ dakora watch</code></pre>
         <div class="container">
             <div class="footer-links">
                 <a href="https://github.com/bogdan-pistol/dakora">GitHub</a>
+                <a href="https://dakora.mintlify.app/" target="_blank">Documentation</a>
                 <a href="https://github.com/bogdan-pistol/dakora/issues">Issues</a>
                 <a href="https://github.com/bogdan-pistol/dakora/blob/main/LICENSE">License</a>
                 <a href="https://pypi.org/project/dakora/">PyPI</a>


### PR DESCRIPTION
Updated the path to assets in index.html from /docs to the new folder: `.github/assets`
The `docs` folder is now used for mintlify docs.